### PR TITLE
Disabled minio version upgrade via Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,6 +2,9 @@
   "extends": [
     "config:base"
   ],
+  "ignoreDeps": [
+    "io.minio:minio"
+  ],
   "labels": [
     "dependencies"
   ],


### PR DESCRIPTION
## Description

This pull request embraces changes on disabling Minio dependency version upgrade via Renovate since the newer version is not compatible with the current app implementation