### PR TITLE
#50: Adding JaCoCo plugin to evaluate code coverage rate

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,8 @@ plugins {
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'java'
     id 'org.hidetake.swagger.generator' version '2.18.2'
-    id "org.sonarqube" version "3.3"
+    id 'org.sonarqube' version '3.3'
+    id 'jacoco'
 }
 
 group = 'kz.toko'
@@ -75,8 +76,10 @@ sourceSets.main.resources.srcDirs += "${buildDir}/generated/src/main/resources"
 sonarqube {
     properties {
         property "sonar.projectKey", "Dauren-Delmukhambetov_cautious-giggle"
+        property "sonar.projectName", "Toko app"
         property "sonar.organization", "dauren-delmukhambetov"
         property "sonar.host.url", "https://sonarcloud.io"
+        property "sonar.jacoco.reportPaths", "${buildDir}/reports/jacoco/test"
     }
 }
 
@@ -95,4 +98,28 @@ bootBuildImage {
 
 test {
     useJUnitPlatform()
+    finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.enabled true
+    }
+}
+
+jacocoTestCoverageVerification {
+    dependsOn check
+    violationRules {
+        rule {
+            limit {
+                minimum = 0.25
+            }
+        }
+    }
+}
+
+check {
+    dependsOn test
+    finalizedBy jacocoTestCoverageVerification
 }


### PR DESCRIPTION
## Description

This pull request closes #50 and embraces changes on adding the `JaCoCo` plugin to evaluate code coverage rate

## Screenshots
<details>
<summary>Code coverage report example</summary>

![image](https://user-images.githubusercontent.com/5857843/129918759-534eca9a-71fb-4fa9-ac4a-f518a0964f60.png)

</details>