### PR TITLE
#112: Refactoring ErrorResponse to ErrorDetails

### DIFF
--- a/api/toko-rest-api.yaml
+++ b/api/toko-rest-api.yaml
@@ -86,13 +86,13 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/ErrorDetails'
         410:
           description: The product has already been deleted
           content:
             application/problem+json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/ErrorDetails'
     patch:
       tags:
         - Products
@@ -119,13 +119,13 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/ErrorDetails'
         410:
           description: The product has already been deleted
           content:
             application/problem+json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/ErrorDetails'
     delete:
       tags:
         - Products
@@ -145,13 +145,13 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/ErrorDetails'
         410:
           description: The product has already been deleted
           content:
             application/problem+json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/ErrorDetails'
   /products/{id}/image:
     post:
       tags:
@@ -182,13 +182,13 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/ErrorDetails'
         410:
           description: The product has already been deleted
           content:
             application/problem+json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/ErrorDetails'
   ## Users API
   /users:
     get:
@@ -251,13 +251,13 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/ErrorDetails'
         410:
           description: The user has already been deleted
           content:
             application/problem+json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/ErrorDetails'
     patch:
       tags:
         - Users
@@ -283,13 +283,13 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/ErrorDetails'
         410:
           description: The user has already been deleted
           content:
             application/problem+json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/ErrorDetails'
 
   /users/{userId}:
     delete:
@@ -316,13 +316,13 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/ErrorDetails'
         410:
           description: User has already been deleted
           content:
             application/problem+json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/ErrorDetails'
 
   ## Stores API
   /stores:
@@ -588,7 +588,7 @@ components:
           type: string
           format: binary
 
-    ErrorResponse:
+    ErrorDetails:
       type: object
       properties:
         message:
@@ -597,6 +597,8 @@ components:
           type: string
         params:
           type: object
+          additionalProperties:
+            type: string
 
   examples:
     addressExample:

--- a/src/main/java/kz/toko/app/controller/errors/GlobalExceptionHandler.java
+++ b/src/main/java/kz/toko/app/controller/errors/GlobalExceptionHandler.java
@@ -1,21 +1,23 @@
 package kz.toko.app.controller.errors;
 
-import kz.toko.api.model.ErrorResponse;
+import kz.toko.api.model.ErrorDetails;
 import kz.toko.app.exception.EntityDeletedException;
 import kz.toko.app.exception.EntityNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
-import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
+import static java.lang.String.format;
 import static org.springframework.http.MediaType.APPLICATION_PROBLEM_JSON;
 
 @Slf4j
@@ -23,45 +25,46 @@ import static org.springframework.http.MediaType.APPLICATION_PROBLEM_JSON;
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(EntityNotFoundException.class)
-    public ResponseEntity<ErrorResponse> handleEntityNotFoundException(EntityNotFoundException e) {
+    public ResponseEntity<ErrorDetails> handleEntityNotFoundException(EntityNotFoundException e) {
         return buildErrorResponse(e, HttpStatus.NOT_FOUND);
     }
 
     @ExceptionHandler(EntityDeletedException.class)
-    public ResponseEntity<ErrorResponse> handleEntityDeletedException(EntityDeletedException e) {
+    public ResponseEntity<ErrorDetails> handleEntityDeletedException(EntityDeletedException e) {
         return buildErrorResponse(e, HttpStatus.GONE);
     }
 
     @ExceptionHandler(RuntimeException.class)
-    public ResponseEntity<ErrorResponse> handleAllUncaughtException(RuntimeException exception) {
+    public ResponseEntity<ErrorDetails> handleAllUncaughtException(RuntimeException exception) {
         log.error("Caught an exception: {}", exception.getMessage());
         return buildErrorResponse(exception, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
     @Override
     protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex, HttpHeaders headers, HttpStatus status, WebRequest request) {
-        List<String> errorList = ex
+        final var errors = ex
                 .getBindingResult()
                 .getFieldErrors()
                 .stream()
-                .map(fieldError -> String.format("%s %s", fieldError.getField(), fieldError.getDefaultMessage()))
-                .collect(Collectors.toList());
+                .collect(Collectors.toMap(FieldError::getField,
+                        fe -> format("%s %s", fe.getField(), fe.getDefaultMessage())));
 
-        ErrorResponse response = new ErrorResponse();
-        response.setExceptionClass(ex.getClass().getName());
-        response.setMessage(ex.getLocalizedMessage());
-        response.setParams(errorList);
+        final var errorDetails = buildErrorDetails(ex, errors);
 
-        return handleExceptionInternal(ex, response, headers, status, request);
+        return handleExceptionInternal(ex, errorDetails, headers, status, request);
     }
 
-    private ResponseEntity<ErrorResponse> buildErrorResponse(Exception exception, HttpStatus httpStatus) {
-        ErrorResponse response = new ErrorResponse();
-        response.setMessage(exception.getMessage());
-        response.setExceptionClass(exception.getClass().getName());
+    private ErrorDetails buildErrorDetails(Exception exception, Map<String, String> params) {
+        return new ErrorDetails()
+                .message(exception.getMessage())
+                .exceptionClass(exception.getClass().getName())
+                .params(params);
+    }
+
+    private ResponseEntity<ErrorDetails> buildErrorResponse(Exception exception, HttpStatus httpStatus) {
         return ResponseEntity
                 .status(httpStatus)
                 .contentType(APPLICATION_PROBLEM_JSON)
-                .body(response);
+                .body(buildErrorDetails(exception, null));
     }
 }

--- a/src/test/java/kz/toko/app/controller/StoresIT.java
+++ b/src/test/java/kz/toko/app/controller/StoresIT.java
@@ -14,6 +14,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import static kz.toko.api.model.CreateStoreRequest.ModeEnum.SELLER;
 import static kz.toko.app.util.TestConstants.TEST_USER_FULL_NAME;
 import static kz.toko.app.util.data.provider.AddressDataProvider.buildAddress;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -74,7 +75,7 @@ class StoresIT extends IntegrationTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message", notNullValue()))
                 .andExpect(jsonPath("$.exceptionClass", notNullValue()))
-                .andExpect(jsonPath("$.params", hasSize(1)));
+                .andExpect(jsonPath("$.params", hasKey("address")));
     }
 
     @Test


### PR DESCRIPTION
## Description

This pull request closes #112 and embraces changes on :
- renaming `ErrorResponse` to `ErrorDetails`;
- making `params` field in `ErrorDetails` a map;
- handling `MethodArgumentNotValidException` in our `GlobalExeptionHandler` to customize message;
- adding tests on validation failure;

## Check-list

- [ ] ~~Project version in `build.gradle` has been updated;~~ (n/a)
- [ ] Unit and integration tests has been added;
- [ ] Changes have been manually tested;